### PR TITLE
Allow empty genopheno and phenodata

### DIFF
--- a/lib/features.py
+++ b/lib/features.py
@@ -662,7 +662,7 @@ def define_key_regions(geneinfo, aggregate, phenodata, threshold = 0, outdir = "
     outregion1.close()
     outregion2.close()
 
-    if phenodata:
+    if os.path.exists(phenodata):
         # Calculate statistical values
         outf = open(outdir + "/" + gene_alias + "/plot_scores.txt", "w")
         print("sample", "group", "ratio", "difference", sep="\t", file=outf)

--- a/single.py
+++ b/single.py
@@ -258,8 +258,11 @@ def run_analysis(feature_info):
     # Genotype versus Phenotype (MBKbase)
     genopheno = os.path.join(workdir, gene, "genopheno_raw.bedGraph")
     # Calculate scores
-    scores_genopheno = genopheno_scores(geneinfo, genopheno, outdir = workdir)
-
+    if os.path.exists(genopheno):
+        scores_genopheno = genopheno_scores(geneinfo, genopheno, outdir = workdir) 
+    else: 
+        scores_genopheno = {}
+    
     # Aggregate scores
     if scores_genopheno:
         scorelist = [scores_oc, scores_motif, scores_cns, scores_ptm, scores_genopheno]


### PR DESCRIPTION
According to the `README.md`, `genopheno` and `phenodata` are optional, but in fact giving empty values to them caused errors. This PR addresses the issuse by fixing conditional branching based on file existence.

Tested with the following command and modified `test/single/config.ini`:

```sh
cd test/single
python3 ../../single.py config.ini
```